### PR TITLE
chore: rename bitswrt-devs → bitswrt GitHub org references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,5 +19,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Defensive guards: `pr-number` digit-only validation, GraphQL `errors` field detection (defends against gh-CLI silent-succeed edge cases), graceful fallback for `$GITHUB_STEP_SUMMARY` etc. when running locally.
 - Local dry-run support — script can run outside GitHub Actions with sensible env defaults.
 
-[Unreleased]: https://github.com/bitswrt-devs/copilot-rereview/compare/v1.0.0...HEAD
-[1.0.0]: https://github.com/bitswrt-devs/copilot-rereview/releases/tag/v1.0.0
+[Unreleased]: https://github.com/bitswrt/copilot-rereview/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/bitswrt/copilot-rereview/releases/tag/v1.0.0

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Re-request Copilot Review
 
 [![Marketplace](https://img.shields.io/badge/Marketplace-Re--request%20Copilot%20Review-blue?logo=github)](https://github.com/marketplace/actions/re-request-copilot-review)
-[![Test](https://github.com/bitswrt-devs/copilot-rereview/actions/workflows/test.yml/badge.svg)](https://github.com/bitswrt-devs/copilot-rereview/actions/workflows/test.yml)
+[![Test](https://github.com/bitswrt/copilot-rereview/actions/workflows/test.yml/badge.svg)](https://github.com/bitswrt/copilot-rereview/actions/workflows/test.yml)
 
 Re-request **GitHub Copilot code review** on a pull request via the GraphQL `requestReviewsByLogin` mutation.
 
@@ -40,7 +40,7 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     steps:
-      - uses: bitswrt-devs/copilot-rereview@v1
+      - uses: bitswrt/copilot-rereview@v1
         with:
           pr-number: ${{ github.event.pull_request.number || github.event.inputs.pr_number }}
           github-token: ${{ secrets.GH_ORG_TOKEN }}
@@ -49,7 +49,7 @@ jobs:
 ### Multi-bot support
 
 ```yaml
-- uses: bitswrt-devs/copilot-rereview@v1
+- uses: bitswrt/copilot-rereview@v1
   with:
     pr-number: ${{ github.event.pull_request.number }}
     github-token: ${{ secrets.GH_ORG_TOKEN }}

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@
 
 If you discover a security issue, please **do not open a public issue**. Instead, report it privately via GitHub's security advisory system:
 
-**[Report a vulnerability](https://github.com/bitswrt-devs/copilot-rereview/security/advisories/new)**
+**[Report a vulnerability](https://github.com/bitswrt/copilot-rereview/security/advisories/new)**
 
 We will acknowledge your report within 5 business days and aim to provide a fix or mitigation within 30 days for confirmed issues.
 

--- a/scripts/rerequest.sh
+++ b/scripts/rerequest.sh
@@ -53,7 +53,7 @@ if [ -z "${GH_TOKEN:-}" ]; then
     echo "Pass it via \`with.github-token\`, e.g.:"
     echo ""
     echo '```yaml'
-    echo "    - uses: bitswrt-devs/copilot-rereview@v1"
+    echo "    - uses: bitswrt/copilot-rereview@v1"
     echo "      with:"
     echo "        pr-number: \${{ github.event.pull_request.number }}"
     echo "        github-token: \${{ secrets.GH_ORG_TOKEN }}"


### PR DESCRIPTION
## Summary

GitHub 公司主组织从 `bitswrt-devs` 改名为裸 `bitswrt` (与业界 facebook/google/microsoft 公司主组织命名惯例对齐). 同步本仓内所有引用.

## 变动

`sed -i 's/bitswrt-devs/bitswrt/g'` 应用于:

- CHANGELOG.md (compare URL)
- README.md (badge URLs)
- SECURITY.md (security advisory URL)
- scripts/rerequest.sh (echo onboarding text)

## 自检

- 全仓 `grep -rEn 'bitswrt-devs' .` 零残留 ✅
- GitHub 提供旧 owner 永久 HTTP redirect, 旧引用短期内仍可解析
- 此 PR 仅同步引用, action 业务逻辑零变动, 已发布 v1.0.x release 不受影响 (immutable releases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only updates documentation/metadata URLs and example `uses:` references to the new GitHub org, with no functional logic changes.
> 
> **Overview**
> Updates repo references from `bitswrt-devs` to `bitswrt` across docs and user-facing output: changelog compare/release links, README workflow badge and `uses:` examples, SECURITY advisory link, and the onboarding snippet echoed in `scripts/rerequest.sh`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10820ca46627b99ea2ee3c79f556a6acd2b83127. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Rename GitHub org references from `bitswrt-devs` to `bitswrt`
> Updates all references to the old org name across [CHANGELOG.md](https://github.com/bitswrt-devs/copilot-rereview/pull/2/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed), [README.md](https://github.com/bitswrt-devs/copilot-rereview/pull/2/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5), [SECURITY.md](https://github.com/bitswrt-devs/copilot-rereview/pull/2/files#diff-f6ed156e4bf5c791680662464b94ea5d753f219ee816b385f67870e2c0d7d4c7), and [scripts/rerequest.sh](https://github.com/bitswrt-devs/copilot-rereview/pull/2/files#diff-6c765cec205590683afede58d5223df9e622f4f53ca9797ebeeff212c1eaab36). No logic changes; only URLs, badge links, and action slugs are affected.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 10820ca.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->