### PR TITLE
fix(summary): replace misleading pseudo-command with structured GraphQL mutation display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Step Summary: replace `### Command` (which displayed a pseudo-shell-command misleading users into thinking they could re-run it in a terminal) with structured `### GraphQL mutation` (variable table) + `### Response` (status + JSON) + folded `Reproduce locally` (a real, copy-pastable `gh api graphql -F ... -f ...` command). Workflow log line also rewritten from `$ <pseudo-command>` to `[gh api graphql] mutation: ...` to drop the misleading `$` shell prompt. Behaviour-preserving display change only — the underlying mutation call is unchanged. Fixes #3.
+
 ## [1.0.0] — 2026-05-03
 
 ### Added

--- a/scripts/rerequest.sh
+++ b/scripts/rerequest.sh
@@ -176,8 +176,9 @@ for raw in "${BOT_LOGINS_ARR[@]}"; do
 done
 
 GH_VERSION=$(gh --version | head -1 | awk '{print $3}')
-CMD="gh api graphql requestReviewsByLogin(prId=$PR_NODE_ID, botLogins=[$BOT_LOGINS_DISPLAY], union=true)"
-echo "$ $CMD"
+# Workflow log line — explicitly NOT a shell command (no $ prompt) to avoid
+# users copy-pasting the pseudo-syntax into a terminal expecting it to run.
+echo "[gh api graphql] mutation: requestReviewsByLogin(pullRequestId=$PR_NODE_ID, botLogins=[$BOT_LOGINS_DISPLAY], union=true)"
 set +e
 # shellcheck disable=SC2016 # $prId/$botLogins are GraphQL variable refs, must NOT shell-expand
 EDIT_OUT=$(gh api graphql "${GH_API_ARGS[@]}" \
@@ -227,21 +228,50 @@ fi
   echo "| Timestamp | $TS |"
   echo "| gh CLI | \`$GH_VERSION\` |"
   echo ""
-  echo "### Command"
+  echo "### GraphQL mutation"
   echo ""
-  echo '```'
-  echo "$ $CMD"
-  echo '```'
+  echo "| Variable | Value |"
+  echo "| --- | --- |"
+  echo "| Operation | \`requestReviewsByLogin\` |"
+  echo "| \`pullRequestId\` | \`$PR_NODE_ID\` |"
+  echo "| \`botLogins\` | \`[$BOT_LOGINS_DISPLAY]\` |"
+  echo "| \`union\` | \`true\` |"
   echo ""
-  echo "### Output"
+  echo "### Response"
   echo ""
-  echo '```'
+  if [ "$STATUS" -eq 0 ]; then
+    echo "✅ Success — no \`errors\` field in response."
+  else
+    echo "❌ Failed (exit \`$STATUS\`)."
+  fi
+  echo ""
+  echo '```json'
   if [ -z "$EDIT_OUT" ]; then
     echo "(no output — gh api returned silently with exit $STATUS)"
   else
     printf '%s\n' "$EDIT_OUT"
   fi
   echo '```'
+  echo ""
+  echo "<details><summary>Reproduce locally</summary>"
+  echo ""
+  echo '```bash'
+  echo "gh api graphql \\"
+  echo "  -F prId='$PR_NODE_ID' \\"
+  for raw in "${BOT_LOGINS_ARR[@]}"; do
+    bot=$(printf '%s' "$raw" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+    [ -z "$bot" ] && continue
+    echo "  -f 'botLogins[]=$bot' \\"
+  done
+  echo "  -f query='mutation(\$prId: ID!, \$botLogins: [String!]) {"
+  echo "    requestReviewsByLogin(input: {"
+  echo "      pullRequestId: \$prId,"
+  echo "      botLogins: \$botLogins,"
+  echo "      union: true"
+  echo "    }) { clientMutationId }"
+  echo "  }'"
+  echo '```'
+  echo "</details>"
 
   if [ "$STATUS" -ne 0 ]; then
     echo ""

--- a/scripts/rerequest.sh
+++ b/scripts/rerequest.sh
@@ -166,13 +166,15 @@ echo "pr-node-id=$PR_NODE_ID" >> "$GITHUB_OUTPUT"
 # Build -F arguments from comma-separated BOT_LOGINS.
 GH_API_ARGS=(-F prId="$PR_NODE_ID")
 IFS=',' read -ra BOT_LOGINS_ARR <<< "$BOT_LOGINS"
-BOT_LOGINS_DISPLAY=""
+BOT_LOGINS_DISPLAY=""   # comma-joined plain (e.g. `a, b`) — used in workflow log + Bots cell
+BOT_LOGINS_QUOTED=""    # comma-joined quoted (e.g. `"a", "b"`) — used in GraphQL [String!] cell so the rendered value is a syntactically valid list literal
 for raw in "${BOT_LOGINS_ARR[@]}"; do
   # Trim each login.
   bot=$(printf '%s' "$raw" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
   [ -z "$bot" ] && continue
   GH_API_ARGS+=(-f "botLogins[]=$bot")
   BOT_LOGINS_DISPLAY="${BOT_LOGINS_DISPLAY:+$BOT_LOGINS_DISPLAY, }$bot"
+  BOT_LOGINS_QUOTED="${BOT_LOGINS_QUOTED:+$BOT_LOGINS_QUOTED, }\"$bot\""
 done
 
 GH_VERSION=$(gh --version | head -1 | awk '{print $3}')
@@ -230,11 +232,14 @@ fi
   echo ""
   echo "### GraphQL mutation"
   echo ""
-  echo "| Variable | Value |"
+  # "Field" header (not "Variable") — Mutation row + 3 input fields below. The
+  # actual GraphQL variables are $prId/$botLogins (see Reproduce locally
+  # block); pullRequestId/botLogins/union are input-object fields.
+  echo "| Field | Value |"
   echo "| --- | --- |"
-  echo "| Operation | \`requestReviewsByLogin\` |"
-  echo "| \`pullRequestId\` | \`$PR_NODE_ID\` |"
-  echo "| \`botLogins\` | \`[$BOT_LOGINS_DISPLAY]\` |"
+  echo "| Mutation | \`requestReviewsByLogin\` |"
+  echo "| \`pullRequestId\` | \`\"$PR_NODE_ID\"\` |"
+  echo "| \`botLogins\` | \`[$BOT_LOGINS_QUOTED]\` |"
   echo "| \`union\` | \`true\` |"
   echo ""
   echo "### Response"

--- a/scripts/rerequest.sh
+++ b/scripts/rerequest.sh
@@ -250,7 +250,15 @@ fi
     echo "❌ Failed (exit \`$STATUS\`)."
   fi
   echo ""
-  echo '```json'
+  # EDIT_OUT can be (1) success JSON, (2) GraphQL errors JSON, or (3) plain
+  # stderr text from gh CLI errors / silent-success placeholder. Only JSON
+  # cases get ```json highlighting — others use a plain fence to avoid
+  # misleading syntax highlighting on non-JSON content.
+  if [ -n "$EDIT_OUT" ] && printf '%s' "$EDIT_OUT" | jq -e . >/dev/null 2>&1; then
+    echo '```json'
+  else
+    echo '```'
+  fi
   if [ -z "$EDIT_OUT" ]; then
     echo "(no output — gh api returned silently with exit $STATUS)"
   else


### PR DESCRIPTION
Closes #3

## Summary

Job summary previously displayed the GraphQL mutation as a pseudo shell command under `### Command`, e.g.:

```
$ gh api graphql requestReviewsByLogin(prId=PR_xxx, botLogins=[...], union=true)
```

This format is **NOT valid `gh api graphql` syntax** (real usage requires `-F`/`-f` with a `query=` mutation string). Users copy-pasting it for debug would get a syntax error and be confused.

This PR rewrites both the workflow-log line and the step summary section into structured, accurate output.

## After

- `### GraphQL mutation` — variable table (Operation / pullRequestId / botLogins / union)
- `### Response` — ✅ Success / ❌ Failed verdict + raw JSON in fenced ```json
- `<details>Reproduce locally</summary>` — real, copy-pastable `gh api graphql -F prId=... -f 'botLogins[]=...' -f query='mutation(...)'`

✅ no shell-prompt confusion  ✅ verdict at-a-glance  ✅ folded reproducer is real syntax users CAN copy-paste  ✅ also serves as inline teaching of correct usage

## Workflow log line

| | |
|---|---|
| Before | `$ gh api graphql requestReviewsByLogin(prId=..., botLogins=[...], union=true)` |
| After | `[gh api graphql] mutation: requestReviewsByLogin(pullRequestId=..., botLogins=[...], union=true)` |

## Behaviour preservation

Underlying mutation call (`scripts/rerequest.sh:183-191`) unchanged. Only display layer changed. `review-requested` / `pr-node-id` outputs unchanged. STATUS detection & error path unchanged.

## Changes

- `scripts/rerequest.sh`: line 178-180 (workflow log) + line 230-244 → 270 (summary section), -8/+42 lines net
- `CHANGELOG.md`: `[Unreleased]` section gets `### Changed` entry

## Verification

- ✅ `bash -n scripts/rerequest.sh` syntax clean
- ✅ Local dry-run on a merged PR renders new summary correctly with all sections
- ✅ Folded `Reproduce locally` per-bot `-f` flags constructed via the same `BOT_LOGINS_ARR` loop the actual `GH_API_ARGS` uses → multi-bot setups produce correct multi-flag command

## Test plan

- [ ] After merge, observe next workflow run's job summary on a real PR — should render new structure
- [ ] Verify multi-bot config (e.g. `bot-logins: 'copilot-pull-request-reviewer[bot],coderabbitai[bot]'`) generates two `-f botLogins[]=...` lines in the folded reproducer
- [ ] Failure path (intentionally broken token) still renders `❌ Failed (exit N)` correctly

## Versioning note

Behaviour-preserving display change → patch bump candidate (e.g. v1.0.2). Callers pinning `@v1` / `@v1.0` get it automatically; callers pinning `@v1.0.1` won't.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to workflow logging and Step Summary rendering, with the underlying GraphQL mutation invocation and success/failure detection unchanged.
> 
> **Overview**
> Updates the action’s output presentation to avoid implying the GraphQL call is a runnable shell command.
> 
> The Step Summary replaces `### Command`/`### Output` with **`### GraphQL mutation`** (structured field/value table) and **`### Response`** (explicit success/failure verdict + JSON-fenced output), and adds a folded **`Reproduce locally`** section that prints a real `gh api graphql -F/-f ... -f query=...` command.
> 
> Also adjusts bot login rendering for the summary table (adds a quoted list form for display) and records the change in `CHANGELOG.md` under `[Unreleased]`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cecf382221111725408831bcfa821e16b884333e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->