### PR TITLE
chore(release): prepare v1.0.2 — CHANGELOG sections + compare links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.2] — 2026-05-03
+
 ### Changed
 
-- Step Summary: replace `### Command` (which displayed a pseudo-shell-command misleading users into thinking they could re-run it in a terminal) with structured `### GraphQL mutation` (variable table) + `### Response` (status + JSON) + folded `Reproduce locally` (a real, copy-pastable `gh api graphql -F ... -f ...` command). Workflow log line also rewritten from `$ <pseudo-command>` to `[gh api graphql] mutation: ...` to drop the misleading `$` shell prompt. Behaviour-preserving display change only — the underlying mutation call is unchanged. Fixes #3.
+- Step Summary: replace `### Command` (which displayed a pseudo-shell-command misleading users into thinking they could re-run it in a terminal) with structured `### GraphQL mutation` (field table) + `### Response` (status + JSON, ` ```json ` fence only when output is parseable JSON) + folded `Reproduce locally` (a real, copy-pastable `gh api graphql -F ... -f ...` command). Workflow log line also rewritten from `$ <pseudo-command>` to `[gh api graphql] mutation: ...` to drop the misleading `$` shell prompt. Behaviour-preserving display change only — the underlying mutation call is unchanged. (#4, fixes #3)
+- Internal: rename GitHub org references `bitswrt-devs` → `bitswrt` across own README, CHANGELOG, SECURITY, and scripts to align with the bitswrt company main-org rename. Old refs continue to work via GitHub's permanent owner redirect; this is a documentation/onboarding cleanup. (#2)
+
+## [1.0.1] — 2026-05-03
+
+### Changed
+
+- Bump `actions/checkout` from 4 to 6 in CI workflows (dependabot). (#1)
 
 ## [1.0.0] — 2026-05-03
 
@@ -23,5 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Defensive guards: `pr-number` digit-only validation, GraphQL `errors` field detection (defends against gh-CLI silent-succeed edge cases), graceful fallback for `$GITHUB_STEP_SUMMARY` etc. when running locally.
 - Local dry-run support — script can run outside GitHub Actions with sensible env defaults.
 
-[Unreleased]: https://github.com/bitswrt/copilot-rereview/compare/v1.0.0...HEAD
+[Unreleased]: https://github.com/bitswrt/copilot-rereview/compare/v1.0.2...HEAD
+[1.0.2]: https://github.com/bitswrt/copilot-rereview/compare/v1.0.1...v1.0.2
+[1.0.1]: https://github.com/bitswrt/copilot-rereview/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/bitswrt/copilot-rereview/releases/tag/v1.0.0


### PR DESCRIPTION
## Summary

Release preparation for **v1.0.2**: move `[Unreleased]` entry into a new `[1.0.2]` section, backfill the missing `[1.0.1]` section, and add proper Keep a Changelog tag compare links.

## Background

Repository CHANGELOG had a gap — `[1.0.1]` was tagged ([bac522b](https://github.com/bitswrt/copilot-rereview/commit/bac522b)) without a CHANGELOG entry. This PR backfills it (it only contained a dependabot bump from #1) and prepares `[1.0.2]` for the upcoming release.

## v1.0.2 contents

| # | PR | Type | Summary |
|---|---|---|---|
| 1 | [#4](https://github.com/bitswrt/copilot-rereview/pull/4) | Changed | Step Summary refactor — pseudo-command → structured GraphQL mutation display with smart JSON fence detection. Fixes #3. |
| 2 | [#2](https://github.com/bitswrt/copilot-rereview/pull/2) | Changed (internal) | Rename `bitswrt-devs` → `bitswrt` org refs across own docs/scripts (bitswrt main-org rename) |

Both behaviour-preserving — no functional changes to the action's mutation call or output contracts.

## Diff

`CHANGELOG.md` only (`+13/-2`). No code changes.

## Test plan

- [x] CHANGELOG syntax valid Markdown
- [x] Compare links resolve correctly
- [ ] After merge: tag `v1.0.2` on this commit, push tag, create GitHub release with notes from `[1.0.2]` section
- [ ] After release: open mirror PRs in caller repos (`nhxwrt/NHX-QSDK-11.5-umac0x`, `nhxwrt/NHX-QSDK-12.5-umac0x`) bumping `@v1.0.1` → `@v1.0.2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only release prep in `CHANGELOG.md`; no code or workflow behavior changes, so risk is minimal aside from potential incorrect release notes/links.
> 
> **Overview**
> Prepares the `v1.0.2` release notes by adding a new `[1.0.2]` section and moving the prior Unreleased change descriptions into it.
> 
> Backfills a missing `[1.0.1]` section (noting the `actions/checkout` 4→6 bump) and updates the Keep a Changelog compare links so `[Unreleased]` now compares from `v1.0.2` and includes new `[1.0.2]`/`[1.0.1]` links.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7770ea1a9e54a5c49c384d87fba19d308ed42c84. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->